### PR TITLE
FIX: package-name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fastbill/fastbill-php-sdk",
-    "description": "FastBill SKD for PHP",
+    "description": "FastBill SDK for PHP",
     "type": "library",
     "require": {
         "guzzlehttp/guzzle": "^5.0|^6.0",


### PR DESCRIPTION
packagist.org reads the description from composer.json, SKD =>SDK