### PR TITLE
Fix getInvoice Service

### DIFF
--- a/src/Item/ItemEntity.php
+++ b/src/Item/ItemEntity.php
@@ -12,6 +12,8 @@ class ItemEntity
     public $customerId;
 
     public $category;
+    
+    public $categoryId;
 
     public $articleNumber;
 
@@ -38,6 +40,7 @@ class ItemEntity
         'INVOICE_ID' => 'invoiceId',
         'CUSTOMER_ID' => 'customerId',
         'CATEGORY' => 'category',
+        'CATEGORY_ID' => 'categoryId',
         'ARTICLE_NUMBER' => 'articleNumber',
         'DESCRIPTION' => 'description',
         'QUANTITY' => 'quantity',
@@ -55,6 +58,7 @@ class ItemEntity
         'invoiceId' => 'INVOICE_ID',
         'customerId' => 'CUSTOMER_ID',
         'category' => 'CATEGORY',
+        'categoryId' => 'CATEGORY_ID',
         'articleNumber' => 'ARTICLE_NUMBER',
         'description' => 'DESCRIPTION',
         'quantity' => 'QUANTITY',


### PR DESCRIPTION
The getInvoice Service throws an mapping error of the missing categoryId if you try to search for an invoice:

![image](https://user-images.githubusercontent.com/10563227/189761541-54451a44-2072-4952-93dd-b3b31ad91f37.png)

I try to get an Invoice by ID:

![image](https://user-images.githubusercontent.com/10563227/189761668-73d6c7d6-eed2-460f-8ea2-edccada1958a.png)
