### PR TITLE
Add missing unit property to ItemEntity class

### DIFF
--- a/src/Item/ItemEntity.php
+++ b/src/Item/ItemEntity.php
@@ -21,6 +21,8 @@ class ItemEntity
 
     public $quantity;
 
+    public $unit;
+
     public $unitPrice;
 
     public $vatPercent;
@@ -44,6 +46,7 @@ class ItemEntity
         'ARTICLE_NUMBER' => 'articleNumber',
         'DESCRIPTION' => 'description',
         'QUANTITY' => 'quantity',
+        'UNIT' => 'unit',
         'UNIT_PRICE' => 'unitPrice',
         'VAT_PERCENT' => 'vatPercent',
         'VAT_VALUE' => 'vatValue',
@@ -62,6 +65,7 @@ class ItemEntity
         'articleNumber' => 'ARTICLE_NUMBER',
         'description' => 'DESCRIPTION',
         'quantity' => 'QUANTITY',
+        'unit' => 'UNIT',
         'unitPrice' => 'UNIT_PRICE',
         'vatPercent' => 'VAT_PERCENT',
         'vatValue' => 'VAT_VALUE',


### PR DESCRIPTION
Hi,

I'm using the latest release `0.1.5`, and got the following error when calling `getInvoice(...)` from `InvoiceService` class:

> the provided xml key UNIT is not mapped at the moment in FastBillSdk\Item\ItemEntity

The missing property was added to the class, as well as to the mapping array, could you please check the changes and merge the PR?