### PR TITLE
Add missing "DELETED_DATE" mapping to "CustomerEntity" class.

### DIFF
--- a/src/Customer/CustomerEntity.php
+++ b/src/Customer/CustomerEntity.php
@@ -91,6 +91,8 @@ class CustomerEntity
 
     public $documentHistoryUrl;
 
+    public $DeletedDate;
+
     public const FIELD_MAPPING = [
         'CUSTOMER_ID' => 'customerId',
         'CUSTOMER_NUMBER' => 'customerNumber',
@@ -133,6 +135,7 @@ class CustomerEntity
         'LASTUPDATE' => 'lastupdate',
         'TAGS' => 'tags',
         'DOCUMENT_HISTORY_URL' => 'documentHistoryUrl',
+        'DELETED_DATE' => 'DeletedDate',
     ];
 
     public const XML_FIELD_MAPPING = [
@@ -177,6 +180,7 @@ class CustomerEntity
         'lastupdate' => 'LASTUPDATE',
         'tags' => 'TAGS',
         'documentHistoryUrl' => 'DOCUMENT_HISTORY_URL',
+        'DeletedDate' => 'DELETED_DATE',
     ];
 
     public function __construct(\SimpleXMLElement $data = null)


### PR DESCRIPTION
Hi,

I'm using the latest release `0.1.6`, and got the following error when calling `createCustomer(...)`, `updateCustomer(...)` from `CustomerService` class:

> the provided xml key DELETED_DATE is not mapped at the moment in FastBillSdk\Customer\CustomerEntity

The missing property was added to the class, as well as to the mapping array, could you please check the changes and merge the PR?