### PR TITLE
Fix missing unit in EstimateItemEntity

### DIFF
--- a/src/Estimate/EstimateItemEntity.php
+++ b/src/Estimate/EstimateItemEntity.php
@@ -13,6 +13,8 @@ class EstimateItemEntity
 
     public $quantity;
 
+    public $unit;
+
     public $unitPrice;
 
     public $vatPercent;
@@ -32,6 +34,7 @@ class EstimateItemEntity
         'ARTICLE_NUMBER' => 'articleNumber',
         'DESCRIPTION' => 'description',
         'QUANTITY' => 'quantity',
+        'UNIT' => 'unit',
         'UNIT_PRICE' => 'unitPrice',
         'VAT_PERCENT' => 'vatPercent',
         'VAT_VALUE' => 'vatValue',
@@ -46,6 +49,7 @@ class EstimateItemEntity
         'articleNumber' => 'ARTICLE_NUMBER',
         'description' => 'DESCRIPTION',
         'quantity' => 'QUANTITY',
+        'unit' => 'UNIT',
         'unitPrice' => 'UNIT_PRICE',
         'vatPercent' => 'VAT_PERCENT',
         'vatValue' => 'VAT_VALUE',


### PR DESCRIPTION
At the moment creating Offers fail because of the missing "unit" attribute. It will show the following error: the provided xml key UNIT is not mapped at the moment in FastBillSdk\Estimate\EstimateItemEntity

This will fix it.