### PR TITLE
Fix updating Empty data

### DIFF
--- a/src/Customer/CustomerEntity.php
+++ b/src/Customer/CustomerEntity.php
@@ -211,7 +211,7 @@ class CustomerEntity
     {
         $xmlData = [];
         foreach (self::XML_FIELD_MAPPING as $key => $value) {
-            if ($this->$key) {
+            if (property_exists($this, $key) && $this->$key !== null) {
                 $xmlData[$value] = $this->$key;
             }
         }


### PR DESCRIPTION
Fix for the ability to remove contact data. Previously, it was not possible to delete values such as a firstname for a company, as empty fields were simply ignored. It is now possible to explicitly set a field to be empty.